### PR TITLE
Initial implementation

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -12,3 +12,4 @@ ignore: |
   manifests/
   vendor/
   compiled/
+  tests/golden/

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,3 +2,38 @@ parameters:
   ocp_drain_monitor:
     =_metadata: {}
     namespace: syn-ocp-drain-monitor
+    namespaceMetadata:
+      annotations:
+        openshift.io/node-selector: "node-role.kubernetes.io/infra="
+      labels:
+        openshift.io/cluster-monitoring: "true"
+
+    images:
+      ocp_drain_monitor_controller:
+        registry: ghcr.io
+        image: appuio/ocp-drain-monitor
+        tag: v0.1.1
+      kube_rbac_proxy:
+        registry: gcr.io
+        image: kubebuilder/kube-rbac-proxy
+        tag: v0.13.1
+
+    manifests_version: ${ocp_drain_monitor:images:ocp_drain_monitor_controller:tag}
+
+    kustomize_input:
+      namespace: ${ocp_drain_monitor:namespace}
+
+    alerts:
+      NodeDrainStuck:
+        enabled: true
+        rule:
+          annotations:
+            description: Node {{$labels.node}} is draining for more than 10 minutes.
+            message: Node {{$labels.node}} is draining for more than 10 minutes.
+            runbook_url: https://hub.syn.tools/ocp-drain-monitor/runbooks/NodeDrainStuck.html
+            summary: Node is draining for more than 10 minutes.
+          expr: |
+            ocp_drain_monitor_node_draining == 1
+          for: 10m
+          labels:
+            severity: warning

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -12,7 +12,7 @@ parameters:
       ocp_drain_monitor_controller:
         registry: ghcr.io
         image: appuio/ocp-drain-monitor
-        tag: v0.1.1
+        tag: v0.1.2
       kube_rbac_proxy:
         registry: gcr.io
         image: kubebuilder/kube-rbac-proxy

--- a/class/ocp-drain-monitor.yml
+++ b/class/ocp-drain-monitor.yml
@@ -9,3 +9,23 @@ parameters:
           - ${_base_directory}/component/main.jsonnet
         input_type: jsonnet
         output_path: ocp-drain-monitor/
+
+      - input_paths:
+          - ${_base_directory}/component/ocp-drain-monitor.jsonnet
+        input_type: jsonnet
+        output_path: ${_base_directory}/ocp-drain-monitor
+        output_type: yaml
+      - input_type: external
+        output_path: .
+        input_paths:
+          - ${_kustomize_wrapper}
+        env_vars:
+          INPUT_DIR: ${_base_directory}/ocp-drain-monitor
+        args:
+          - \${compiled_target_dir}/ocp-drain-monitor
+
+      # Cleanup
+      - input_paths:
+          - ${_base_directory}/ocp-drain-monitor
+        input_type: remove
+        output_path: .

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -32,8 +32,5 @@ local alerts = function(name, groupName, alerts)
   });
 
 {
-  '00_namespace': kube.Namespace(params.namespace) {
-    metadata+: com.makeMergeable(params.namespaceMetadata),
-  },
   '10_prometheusrule': alerts('ocp-drain-monitor', 'drain.alerts', params.alerts),
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,10 +1,39 @@
 // main template for ocp-drain-monitor
+local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.ocp_drain_monitor;
 
-// Define outputs below
+local alertlabels = {
+  syn: 'true',
+  syn_component: 'ocp-drain-monitor',
+};
+
+local alerts = function(name, groupName, alerts)
+  com.namespaced(params.namespace, kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', name) {
+    spec+: {
+      groups+: [
+        {
+          name: groupName,
+          rules:
+            std.sort(std.filterMap(
+              function(field) alerts[field].enabled == true,
+              function(field) alerts[field].rule {
+                alert: field,
+                labels+: alertlabels,
+              },
+              std.objectFields(alerts)
+            )),
+        },
+      ],
+    },
+  });
+
 {
+  '00_namespace': kube.Namespace(params.namespace) {
+    metadata+: com.makeMergeable(params.namespaceMetadata),
+  },
+  '10_prometheusrule': alerts('ocp-drain-monitor', 'drain.alerts', params.alerts),
 }

--- a/component/ocp-drain-monitor.jsonnet
+++ b/component/ocp-drain-monitor.jsonnet
@@ -1,0 +1,47 @@
+// main template for openshift4-slos
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local slo = import 'slos.libsonnet';
+
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.ocp_drain_monitor;
+
+local upstreamNamespace = 'ocp-drain-monitor-system';
+
+local removeUpstreamNamespace = {
+  patch: std.manifestJsonMinified({
+    '$patch': 'delete',
+    apiVersion: 'v1',
+    kind: 'Namespace',
+    metadata: {
+      name: upstreamNamespace,
+    },
+  }),
+};
+
+com.Kustomization(
+  'https://github.com/appuio/ocp-drain-monitor//config/default',
+  params.manifests_version,
+  {
+    'ghcr.io/appuio/ocp-drain-monitor': {
+      local image = params.images.ocp_drain_monitor_controller,
+      newTag: image.tag,
+      newName: '%(registry)s/%(image)s' % image,
+    },
+    'gcr.io/kubebuilder/kube-rbac-proxy': {
+      local image = params.images.kube_rbac_proxy,
+      newTag: image.tag,
+      newName: '%(registry)s/%(image)s' % image,
+    },
+  },
+  params.kustomize_input {
+    patches+: [
+      removeUpstreamNamespace,
+    ],
+    patchesStrategicMerge+: [
+    ],
+  },
+)

--- a/component/ocp-drain-monitor.jsonnet
+++ b/component/ocp-drain-monitor.jsonnet
@@ -11,15 +11,14 @@ local params = inv.parameters.ocp_drain_monitor;
 
 local upstreamNamespace = 'ocp-drain-monitor-system';
 
-local removeUpstreamNamespace = {
-  patch: std.manifestJsonMinified({
-    '$patch': 'delete',
-    apiVersion: 'v1',
-    kind: 'Namespace',
-    metadata: {
-      name: upstreamNamespace,
-    },
-  }),
+local removeUpstreamNamespace = kube.Namespace(upstreamNamespace) {
+  metadata: {
+    name: upstreamNamespace,
+  } + params.namespaceMetadata,
+};
+
+local patch = function(p) {
+  patch: std.manifestJsonMinified(p),
 };
 
 com.Kustomization(
@@ -39,9 +38,7 @@ com.Kustomization(
   },
   params.kustomize_input {
     patches+: [
-      removeUpstreamNamespace,
-    ],
-    patchesStrategicMerge+: [
+      patch(removeUpstreamNamespace),
     ],
   },
 )

--- a/component/ocp-drain-monitor.jsonnet
+++ b/component/ocp-drain-monitor.jsonnet
@@ -14,7 +14,7 @@ local upstreamNamespace = 'ocp-drain-monitor-system';
 local removeUpstreamNamespace = kube.Namespace(upstreamNamespace) {
   metadata: {
     name: upstreamNamespace,
-  } + params.namespaceMetadata,
+  } + com.makeMergeable(params.namespaceMetadata),
 };
 
 local patch = function(p) {
@@ -39,6 +39,13 @@ com.Kustomization(
   params.kustomize_input {
     patches+: [
       patch(removeUpstreamNamespace),
+    ],
+    labels+: [
+      {
+        pairs: {
+          'app.kubernetes.io/managed-by': 'commodore',
+        },
+      },
     ],
   },
 )

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -11,9 +11,80 @@ default:: `syn-ocp-drain-monitor`
 The namespace in which to deploy this component.
 
 
-== Example
+== `namespaceMetadata`
 
+[horizontal]
+type:: dict
+default::
++
 [source,yaml]
 ----
-namespace: example-namespace
+annotations:
+  openshift.io/node-selector: "node-role.kubernetes.io/infra="
+labels:
+  openshift.io/cluster-monitoring: "true"
 ----
+
+Metadata to be added to the namespace.
+
+
+== `images`
+
+[horizontal]
+type:: dictionary
+
+The images to use for this component.
+
+
+== `manifests_version`
+
+[horizontal]
+type:: string
+default:: `${ocp_drain_monitor:images:ocp_drain_monitor_controller:tag}`
+
+The Git reference to the controller deployment manifests.
+The default is the tag of the controller image.
+
+
+== `alerts`
+
+[horizontal]
+type:: dict
+example::
++
+[source,yaml]
+----
+BadThingsHappening:
+  enabled: true
+  rule:
+    annotations:
+      description: Bad things have been happening on {{$labels.node}} for more than 10 minutes.
+      message: Bad things have been happening on {{$labels.node}} for more than 10 minutes.
+      runbook_url: https://hub.syn.tools/ocp-drain-monitor/runbooks/BadThingsHappening.html
+    expr: |
+      bad_thing_happening == 1
+    for: 10m
+    labels:
+      severity: warning
+----
+
+`alerts` defines the alerts to be installed.
+The dictionary key is used as the name of the alert.
+
+
+=== `alerts.<name>.enabled`
+
+[horizontal]
+type:: bool
+
+Defines whether to install the alert.
+
+
+=== `alerts.<name>.rule`
+
+[horizontal]
+type:: dict
+
+Holds the configuration of the alert rule.
+
+See https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/[Prometheus Alerting Rules] for details.

--- a/docs/modules/ROOT/pages/runbooks/NodeDrainStuck.adoc
+++ b/docs/modules/ROOT/pages/runbooks/NodeDrainStuck.adoc
@@ -1,0 +1,71 @@
+= NodeDrainStuck
+
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+This alert fires when a node is stuck in the drain process for more than the set amount of time.
+Default is 10 minutes.
+
+This can hold up the maintenance process and delay the upgrade of the cluster.
+
+== icon:bug[] Steps for debugging
+
+Nodes usually get stuck in the drain process when there is a pod that isn't evictable.
+This can be caused by a (rogue) `PodDisruptionBudget`, pods on new nodes not entering a `Ready` state, or extremely long `terminationGracePeriodSeconds` among other things.
+
+=== icon:search[] Check operator logs
+
+The drain process on OpenShift is initiated by the `machine-config-operator`.
+The operator logs reasons for why a node isn't draining.
+You can find these logs by running the following command:
+
+[source,shell]
+----
+kubectl -n openshift-machine-config-operator logs deployments/machine-config-controller
+----
+
+Look out for messages like the following:
+
+[source]
+----
+E0116 14:26:30.051014       1 drain_controller.go:110] error when evicting pods/"apiserver-786c87d87d-9lkxw" -n "openshift-oauth-apiserver" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+----
+
+[NOTE]
+====
+Add the `PodDisruptionBudget` found to cause the issue to the maintenance log.
+
+Create a customer ticket to get the `PodDisruptionBudget` fixed if possible.
+====
+
+=== icon:search[] Check pods on node
+
+You can list the pods on the node by running the following command:
+
+[source,shell]
+----
+kubectl get pods --all-namespaces --field-selector spec.nodeName=$NODE_NAME
+----
+
+Check for pods (for example database pods) that might lead to data loss if evicted.
+
+=== icon:gears[] Force drain the node
+
+If the node is stuck in the drain process for a long time, you can force the drain by running the following command:
+
+[source,shell]
+----
+kubectl drain --force --ignore-daemonsets --delete-emptydir-data --grace-period=30 $NODE_NAME
+----
+
+[CAUTION]
+====
+This can lead to data loss depending on the application.
+Check pods left on node first.
+====
+
+== icon:wrench[] Tune
+
+If this alert isn't actionable, noisy, or was raised too early you may want to tune the time until the alert fires.
+You can do this by changing the `for` parameter in the `NodeDrainStuck` alert configuration.

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,2 +1,5 @@
 * xref:index.adoc[Home]
 * xref:references/parameters.adoc[Parameters]
+
+* Runbooks
+** xref:runbooks/NodeDrainStuck.adoc[NodeDrainStuck]

--- a/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
+++ b/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
@@ -1,0 +1,5 @@
+[NOTE]
+====
+Please consider opening a PR to improve this runbook if you gain new information about causes of the alert, or how to debug or resolve the alert.
+Click "Edit this Page" in the top right corner to create a PR directly on GitHub.
+====

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/00_namespace.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/00_namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: node-role.kubernetes.io/infra=
+  labels:
+    name: syn-ocp-drain-monitor
+    openshift.io/cluster-monitoring: 'true'
+  name: syn-ocp-drain-monitor

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/00_namespace.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/00_namespace.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    openshift.io/node-selector: node-role.kubernetes.io/infra=
-  labels:
-    name: syn-ocp-drain-monitor
-    openshift.io/cluster-monitoring: 'true'
-  name: syn-ocp-drain-monitor

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/10_prometheusrule.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/10_prometheusrule.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: ocp-drain-monitor
+  name: ocp-drain-monitor
+  namespace: syn-ocp-drain-monitor
+spec:
+  groups:
+    - name: drain.alerts
+      rules:
+        - alert: NodeDrainStuck
+          annotations:
+            description: Node {{$labels.node}} is draining for more than 10 minutes.
+            message: Node {{$labels.node}} is draining for more than 10 minutes.
+            runbook_url: https://hub.syn.tools/ocp-drain-monitor/runbooks/NodeDrainStuck.html
+            summary: Node is draining for more than 10 minutes.
+          expr: 'ocp_drain_monitor_node_draining == 1
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: ocp-drain-monitor

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/apps_v1_deployment_ocp-drain-monitor-controller-manager.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/apps_v1_deployment_ocp-drain-monitor-controller-manager.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: ocp-drain-monitor
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: ocp-drain-monitor
+    control-plane: controller-manager
+  name: ocp-drain-monitor-controller-manager
+  namespace: syn-ocp-drain-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+                - ppc64le
+                - s390x
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        image: ghcr.io/appuio/ocp-drain-monitor:v0.1.1
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: ocp-drain-monitor-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/apps_v1_deployment_ocp-drain-monitor-controller-manager.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/apps_v1_deployment_ocp-drain-monitor-controller-manager.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: ocp-drain-monitor
     app.kubernetes.io/instance: controller-manager
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: deployment
     app.kubernetes.io/part-of: ocp-drain-monitor
     control-plane: controller-manager

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/apps_v1_deployment_ocp-drain-monitor-controller-manager.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/apps_v1_deployment_ocp-drain-monitor-controller-manager.yaml
@@ -67,7 +67,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        image: ghcr.io/appuio/ocp-drain-monitor:v0.1.1
+        image: ghcr.io/appuio/ocp-drain-monitor:v0.1.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/monitoring.coreos.com_v1_servicemonitor_ocp-drain-monitor-controller-manager-metrics-monitor.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/monitoring.coreos.com_v1_servicemonitor_ocp-drain-monitor-controller-manager-metrics-monitor.yaml
@@ -14,6 +14,11 @@ metadata:
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    metricRelabelings:
+    - action: keep
+      regex: ocp_drain_monitor_.+
+      sourceLabels:
+      - __name__
     path: /metrics
     port: https
     scheme: https

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/monitoring.coreos.com_v1_servicemonitor_ocp-drain-monitor-controller-manager-metrics-monitor.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/monitoring.coreos.com_v1_servicemonitor_ocp-drain-monitor-controller-manager-metrics-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: ocp-drain-monitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/part-of: ocp-drain-monitor
     control-plane: controller-manager

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/monitoring.coreos.com_v1_servicemonitor_ocp-drain-monitor-controller-manager-metrics-monitor.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/monitoring.coreos.com_v1_servicemonitor_ocp-drain-monitor-controller-manager-metrics-monitor.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: ocp-drain-monitor
+    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/part-of: ocp-drain-monitor
+    control-plane: controller-manager
+  name: ocp-drain-monitor-controller-manager-metrics-monitor
+  namespace: syn-ocp-drain-monitor
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-manager-role.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-manager-role.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: commodore
   name: ocp-drain-monitor-manager-role
 rules:
 - apiGroups:

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-manager-role.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-manager-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: ocp-drain-monitor-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-metrics-reader.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-metrics-reader.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: ocp-drain-monitor
     app.kubernetes.io/instance: metrics-reader
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/part-of: ocp-drain-monitor
   name: ocp-drain-monitor-metrics-reader

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-metrics-reader.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-metrics-reader.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: ocp-drain-monitor
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: ocp-drain-monitor
+  name: ocp-drain-monitor-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-proxy-role.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-proxy-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: ocp-drain-monitor
     app.kubernetes.io/instance: proxy-role
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/part-of: ocp-drain-monitor
   name: ocp-drain-monitor-proxy-role

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-proxy-role.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrole_ocp-drain-monitor-proxy-role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: ocp-drain-monitor
+    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: ocp-drain-monitor
+  name: ocp-drain-monitor-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrolebinding_ocp-drain-monitor-manager-rolebinding.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrolebinding_ocp-drain-monitor-manager-rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: ocp-drain-monitor
     app.kubernetes.io/instance: manager-rolebinding
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/part-of: ocp-drain-monitor
   name: ocp-drain-monitor-manager-rolebinding

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrolebinding_ocp-drain-monitor-manager-rolebinding.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrolebinding_ocp-drain-monitor-manager-rolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: ocp-drain-monitor
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: ocp-drain-monitor
+  name: ocp-drain-monitor-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ocp-drain-monitor-manager-role
+subjects:
+- kind: ServiceAccount
+  name: ocp-drain-monitor-controller-manager
+  namespace: syn-ocp-drain-monitor

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrolebinding_ocp-drain-monitor-proxy-rolebinding.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrolebinding_ocp-drain-monitor-proxy-rolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: ocp-drain-monitor
+    app.kubernetes.io/instance: proxy-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: ocp-drain-monitor
+  name: ocp-drain-monitor-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ocp-drain-monitor-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: ocp-drain-monitor-controller-manager
+  namespace: syn-ocp-drain-monitor

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrolebinding_ocp-drain-monitor-proxy-rolebinding.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_clusterrolebinding_ocp-drain-monitor-proxy-rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: ocp-drain-monitor
     app.kubernetes.io/instance: proxy-rolebinding
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/part-of: ocp-drain-monitor
   name: ocp-drain-monitor-proxy-rolebinding

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_role_ocp-drain-monitor-leader-election-role.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_role_ocp-drain-monitor-leader-election-role.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: ocp-drain-monitor
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: ocp-drain-monitor
+  name: ocp-drain-monitor-leader-election-role
+  namespace: syn-ocp-drain-monitor
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_role_ocp-drain-monitor-leader-election-role.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_role_ocp-drain-monitor-leader-election-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: ocp-drain-monitor
     app.kubernetes.io/instance: leader-election-role
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: role
     app.kubernetes.io/part-of: ocp-drain-monitor
   name: ocp-drain-monitor-leader-election-role

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_rolebinding_ocp-drain-monitor-leader-election-rolebinding.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_rolebinding_ocp-drain-monitor-leader-election-rolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: ocp-drain-monitor
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: ocp-drain-monitor
+  name: ocp-drain-monitor-leader-election-rolebinding
+  namespace: syn-ocp-drain-monitor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ocp-drain-monitor-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: ocp-drain-monitor-controller-manager
+  namespace: syn-ocp-drain-monitor

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_rolebinding_ocp-drain-monitor-leader-election-rolebinding.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/rbac.authorization.k8s.io_v1_rolebinding_ocp-drain-monitor-leader-election-rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: ocp-drain-monitor
     app.kubernetes.io/instance: leader-election-rolebinding
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: rolebinding
     app.kubernetes.io/part-of: ocp-drain-monitor
   name: ocp-drain-monitor-leader-election-rolebinding

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_namespace_syn-ocp-drain-monitor.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_namespace_syn-ocp-drain-monitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: ocp-drain-monitor
     app.kubernetes.io/instance: system
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: namespace
     app.kubernetes.io/part-of: ocp-drain-monitor
     control-plane: controller-manager

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_namespace_syn-ocp-drain-monitor.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_namespace_syn-ocp-drain-monitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: node-role.kubernetes.io/infra=
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: ocp-drain-monitor
+    app.kubernetes.io/instance: system
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: namespace
+    app.kubernetes.io/part-of: ocp-drain-monitor
+    control-plane: controller-manager
+    openshift.io/cluster-monitoring: "true"
+  name: syn-ocp-drain-monitor

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_service_ocp-drain-monitor-controller-manager-metrics-service.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_service_ocp-drain-monitor-controller-manager-metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: ocp-drain-monitor
     app.kubernetes.io/instance: controller-manager-metrics-service
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: service
     app.kubernetes.io/part-of: ocp-drain-monitor
     control-plane: controller-manager

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_service_ocp-drain-monitor-controller-manager-metrics-service.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_service_ocp-drain-monitor-controller-manager-metrics-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: ocp-drain-monitor
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: ocp-drain-monitor
+    control-plane: controller-manager
+  name: ocp-drain-monitor-controller-manager-metrics-service
+  namespace: syn-ocp-drain-monitor
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_serviceaccount_ocp-drain-monitor-controller-manager.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_serviceaccount_ocp-drain-monitor-controller-manager.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: ocp-drain-monitor
     app.kubernetes.io/instance: controller-manager
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: serviceaccount
     app.kubernetes.io/part-of: ocp-drain-monitor
   name: ocp-drain-monitor-controller-manager

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_serviceaccount_ocp-drain-monitor-controller-manager.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/v1_serviceaccount_ocp-drain-monitor-controller-manager.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: ocp-drain-monitor
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: ocp-drain-monitor
+  name: ocp-drain-monitor-controller-manager
+  namespace: syn-ocp-drain-monitor


### PR DESCRIPTION
Deployment of the `ocp-drain-monitor` and a `NodeDrainStuck` alert firing after 10 minutes.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
