### PR TITLE
Add `Maintenance: "true"` label to alert

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -37,3 +37,4 @@ parameters:
           for: 10m
           labels:
             severity: warning
+            Maintenance: "true"

--- a/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/10_prometheusrule.yaml
+++ b/tests/golden/defaults/ocp-drain-monitor/ocp-drain-monitor/10_prometheusrule.yaml
@@ -21,6 +21,7 @@ spec:
             '
           for: 10m
           labels:
+            Maintenance: 'true'
             severity: warning
             syn: 'true'
             syn_component: ocp-drain-monitor


### PR DESCRIPTION
We've defined (but not documented yet) that all maintenance-relevant alerts have the label `Maintenance: "true"`.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
